### PR TITLE
add start and build npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 ## Install the dependencies
 ```bash
-yarn
+yarn install
 # or
 npm install
 ```
 
 ### Start the app in development mode (hot-code reloading, error reporting, etc.)
 ```bash
-quasar dev
-# or if quasar is not installed globally
-./node_modules/.bin/quasar dev
+yarn start
+# or
+npm run start
 ```
 
 ### Lint the files
@@ -22,6 +22,7 @@ yarn lint
 # or
 npm run lint
 ```
+
 ### Format the files
 ```bash
 yarn format
@@ -31,16 +32,16 @@ npm run format
 
 ### Build the app for production in PWA mode:
 ```bash
-quasar build -m pwa
-# or if quasar is not installed globally
-./node_modules/.bin/quasar build -m pwa
+yarn build:pwa
+# or
+npm run build:pwa
 ```
 
 ### Build the app for production in SPA mode:
 ```bash
-quasar build
-# or if quasar is not installed globally
-./node_modules/.bin/quasar build
+yarn build:spa
+# or
+npm run build:spa
 ```
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@
 
 ## Install the dependencies
 ```bash
-yarn install
+yarn
 # or
 npm install
 ```
 
 ### Start the app in development mode (hot-code reloading, error reporting, etc.)
 ```bash
-yarn start
+yarn dev
 # or
-npm run start
+npm run dev
+# or if quasar installed locally
+quasar dev
 ```
 
 ### Lint the files
@@ -35,6 +37,8 @@ npm run format
 yarn build:pwa
 # or
 npm run build:pwa
+# or if quasar installed locally
+quasar build -m pwa
 ```
 
 ### Build the app for production in SPA mode:
@@ -42,6 +46,8 @@ npm run build:pwa
 yarn build:spa
 # or
 npm run build:spa
+# or if quasar installed locally
+quasar build
 ```
 
 ## Docker

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "monica <monlovesmango@protonmail.com>",
   "private": true,
   "scripts": {
-    "start": "quasar dev",
+    "dev": "quasar dev",
     "build:pwa": "quasar build -m pwa",
     "build:spa": "quasar build",
     "lint": "eslint --ext .js,.vue ./",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "monica <monlovesmango@protonmail.com>",
   "private": true,
   "scripts": {
+    "start": "quasar dev",
+    "build:pwa": "quasar build -m pwa",
+    "build:spa": "quasar build",
     "lint": "eslint --ext .js,.vue ./",
     "format": "prettier --write \"**/*.{js,vue,scss,html,md,json}\" --ignore-path .gitignore",
     "test": "echo \"No test specified\" && exit 0"


### PR DESCRIPTION
Added the `start`, `build:pwa`, and `build:spa` scripts and updated the readme.

This should simplify starting or building the app since calling `quasar` in a npm script will either run it from `./node_modules/.bin/quasar` or globally if its not installed in the `node_modules`