### PR TITLE
added profile tooltip

### DIFF
--- a/src/components/BaseUserAvatar.vue
+++ b/src/components/BaseUserAvatar.vue
@@ -9,6 +9,31 @@
           button-size='xs'
         />
       </div>
+      <q-tooltip anchor="top middle" self="bottom middle" :delay="1500">
+        <div>
+          <BaseUserAvatar
+            :pubkey="pubkey"
+            :align-right='alignRight'
+            :size='headerMode ? "10rem" : "lg"'
+            :class='headerMode ? "self-center" : ""'
+          />
+        </div>
+        <q-item-section
+          :class='headerMode ? "self-start" : ""'
+          :style='!headerMode ? "white-space: nowrap; overflow: auto;" : ""'
+        >
+          <BaseUserName
+            :pubkey="pubkey"
+            :header-mode='headerMode'
+            :show-verified='true'
+            :class='headerMode ? " text-h6" : ""'
+            :align-right='alignRight'
+            :show-following='showFollowing'
+            :wrap='wrap'
+          />
+          <div>{{ $store.getters.profileDescription(pubkey) }}</div>
+        </q-item-section>
+      </q-tooltip>
     </q-avatar>
   </div>
 </template>


### PR DESCRIPTION
While scrolling through feeds, users might want to quickly view a profiles description without having to navigate to their profile page. The PR provides a tooltip functionality where if the user hovers the mouse pointer over an avatar image for 1.5 seconds a tooltip pops up showing the avatar, username, and profile description.
![pr_image1](https://user-images.githubusercontent.com/30268344/210154864-897270f5-432c-4627-abb9-7793ff86b2dc.png)
![pr_image1_zoomed](https://user-images.githubusercontent.com/30268344/210154865-ceda054b-2ddf-458d-b336-cf9fe2a6910c.png)
![pr_image2](https://user-images.githubusercontent.com/30268344/210154867-b32c72e6-4b04-4b1f-b98a-9f06114336de.png)

Changes made (only one file BaseUserAvatar.vue):
q-tooltip was added to BaseUserAvatar with a delay of 1500 which creates a pop upof the users avatar image, name, and profile description using BaseUserName and store.getters.profileDesctiption(). Allows users to access this tooltip anywhere BaseUserAvatar is referenced (followerFeed, globalFeed, Follows, and Messages)