### PR TITLE
Update Strike Wallet Prefix

### DIFF
--- a/src/components/BaseWallet.vue
+++ b/src/components/BaseWallet.vue
@@ -122,7 +122,7 @@ export default defineComponent({
         },
         {
           name: 'Strike',
-          prefix: 'strike:',
+          prefix: 'strike:lightning:',
           image: 'strike.jpg',
         },
         {


### PR DESCRIPTION
I couldn't get the Strike wallet option to work for me, so I took a look at Bitrefill.com to see what prefix they're using for Strike (they have a good wallet picker at checkout). They're using `strike:lighting:lnbc...`. This commit updates Astral to reflect this.