### PR TITLE
Public relay name change

### DIFF
--- a/src/store/state.js
+++ b/src/store/state.js
@@ -6,7 +6,6 @@ const mainnetDefaultRelays = {
     'wss://nostr-pub.wellorder.net': {read: true, write: true},
     'wss://nostr.onsats.org': {read: true, write: true},
     'wss://nostr-relay.wlvs.space': {read: true, write: true},
-    'wss://nostr.bitcoiner.social': {read: true, write: true},
     'wss://relay.damus.io': {read: true, write: true},
     'wss://nostr.zebedee.cloud': {read: true, write: false},
     'wss://relay.nostr.info': {read: true, write: true},
@@ -17,7 +16,6 @@ const mainnetDefaultRelays = {
   //   ['wss://nostr.rocks', {read: true, write: true}],
   //   ['wss://nostr.onsats.org', {read: true, write: true}],
   //   ['wss://nostr-relay.wlvs.space', {read: true, write: true}],
-  //   ['wss://nostr.bitcoiner.social', {read: true, write: true}],
   //   ["wss://relay.damus.io", {read: true, write: true}],
   // ]
   const mainnetOptionalRelays = [
@@ -33,7 +31,7 @@ const mainnetDefaultRelays = {
     'wss://expensive-relay.fiatjaf.com',
     'wss://freedom-relay.herokuapp.com/ws',
     'wss://nostr-relay.freeberty.net',
-    'wss://nostr.bitcoiner.social',
+    'wss://offchain.pub',
     'wss://nostr-relay.wlvs.space',
     'wss://nostr.onsats.org',
     'wss://nostr-relay.untethr.me',


### PR DESCRIPTION
nostr.bitcoiner.social -> offchain.pub

note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74

I also pulled it out of the default relay list because I've been starting to realize that I don't think I can sustain a free relay by myself long-term, even with funds from the pay-to-relay server. Nostr relays will need to host files for applications like "github on nostr" and at a certain point I will need to experiment with non-free models for that to work.